### PR TITLE
Add support for Gnome Shell 3.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,42 @@ Tiling window manager
 git clone https://github.com/rliang/gnome-shell-extension-tilingnome ~/.local/share/gnome-shell/extensions/tilingnome@rliang.github.com
 ```
 
+## Usage
+
+Most of your daily interactions with the Tilingnome will be through the use of keyboard shortcuts. The available ones are listed below.
+
+### Tiles
+
+| Key                      | Function            | Description                                         |
+| ------------------------ | ------------------- | --------------------------------------------------- |
+| Super+__x__              | Toggle tile         | Toggle whether to tile the currently-focused window |
+| Super+__return__         | Focus first tile    | Focus the first tile in the tile list               |
+| Super+__j__              | Focus next tile     | Focus the next tile in the tile list                |
+| Super+__k__              | Focus previous tile | Focus the previous tile in the tile list            |
+| _Shift_+Super+__return__ | Swap first tile     | Swap currently-focused tile with the first tile     |
+| _Shift_+Super+__j__      | Swap next tile      | Swap currently-focused tile with the next tile      |
+| _Shift_+Super+__k__      | Swap prev tile      | Swap currently-focused tile with the previous tile  |
+
+### Layouts
+
+| Key                      | Function               | Description                                         |
+| ------------------------ | ---------------------- | --------------------------------------------------- |
+| Super+__z__              | Switch next layout     | Switch to the next available layout                 |
+| _Shift_+Super+__z__      | Switch previous layout | Switch to the previous available layout             |
+
+### Settings
+
+You can also modify these from the Settings panel for the Tilingnome extension in [Gnome Tweaks](https://wiki.gnome.org/Apps/Tweaks).
+
+| Key                      | Function               | Description                                         |
+| ------------------------ | ---------------------- | --------------------------------------------------- |
+| Super+__l__              | Decrease split         | Decrease the split ratio by the split ratio step    |
+| Super+__h__\*            | Increase split         | Increase the split ratio by the split ratio step    |
+| _Shift_+Super+__l__      | Decrease master count  | Decreate the master count by one                    |
+| _Shift_+Super+__h__      | Increase master count  | Increase the master count by one                    |
+
+\* May conflict with the Hide Window shortcut on some distributions (e.g., it does on Pop!_OS). To change a keybinding, you must edit the _schema.gschema.xml_ file in the source, run [glib-compile-schemas](https://developer.gnome.org/gio/stable/glib-compile-schemas.html) in the source directory, and then reload the extension either by restarting Gnome Shell on X11 (`alt+F2 r`) or logging out and logging back in on Wayland.
+
 ## Contributing
 
 Pull requests welcome for features and fixes!

--- a/extension.js
+++ b/extension.js
@@ -131,7 +131,13 @@ function swapTiles(w1, w2) {
 }
 
 function addKeybinding(name, handler) {
-  Main.wm.addKeybinding(name, bindings, 0, Shell.ActionMode.NORMAL, handler);
+  if (Main.wm.addKeybinding && Shell.ActionMode) { // introduced in 3.16
+    Main.wm.addKeybinding(name, bindings, Meta.KeyBindingFlags.NONE, Shell.ActionMode.NORMAL, handler);
+  } else if (Main.wm.addKeybinding && Shell.KeyBindingMode) { // introduced in 3.7.5
+    Main.wm.addKeybinding(name, bindings, Meta.KeyBindingFlags.NONE, Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY, handler);
+  } else {
+    global.display.add_keybinding(name, bindings, Meta.KeyBindingFlags.NONE, handler);
+  }
 }
 
 function enable() {

--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,7 @@ const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
 const Main = imports.ui.main;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Utils = Me.imports.utils;
 
 const SchemaSource = Gio.SettingsSchemaSource.new_from_directory(
   Me.dir.get_path(), Gio.SettingsSchemaSource.get_default(), false);
@@ -64,7 +65,7 @@ function refreshTile(win, idx, rect) {
 }
 
 function refreshMonitor(mon) {
-  const wksp = global.screen.get_active_workspace();
+  const wksp = Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace();
   const wins = wksp.list_windows()
     .filter(win => win.get_monitor() === mon)
     .filter(win => !win.fullscreen)
@@ -85,7 +86,7 @@ function refreshMonitor(mon) {
 
 function refresh() {
   Meta.later_add(Meta.LaterType.RESIZE, () => {
-    for (let m = 0; m < global.screen.get_n_monitors(); m++)
+    for (let m = 0; m < Utils.DisplayWrapper.getScreen().get_n_monitors(); m++)
       refreshMonitor(m);
   });
 }
@@ -109,12 +110,12 @@ function isTileable(win) {
 }
 
 function getCurrentTiles() {
-  return global.screen.get_active_workspace().list_windows()
+  return Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace().list_windows()
     .filter(tileInfo).sort(tileSort);
 }
 
 function getFocusedWindow(win) {
-  return global.screen.get_active_workspace().list_windows()
+  return Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace().list_windows()
     .filter(win => win.has_focus())[0];
 }
 
@@ -135,7 +136,7 @@ function addKeybinding(name, handler) {
 
 function enable() {
   _handle_gs = settings.connect('changed', refresh);
-  _handle_sc = global.screen.connect('restacked', refresh);
+  _handle_sc = Utils.DisplayWrapper.getScreen().connect('restacked', refresh);
   _handle_wm0 = global.window_manager.connect('switch-workspace', refresh);
   _handle_wm1 = global.window_manager.connect('map', (g, w) => {
     if (isTileable(w.meta_window))
@@ -231,7 +232,7 @@ function enable() {
 
 function disable() {
   settings.disconnect(_handle_gs);
-  global.screen.disconnect(_handle_sc);
+  Utils.DisplayWrapper.getScreen().disconnect(_handle_sc);
   global.display.disconnect(_handle_display);
   global.window_manager.disconnect(_handle_wm0);
   global.window_manager.disconnect(_handle_wm1);

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Tilingnome",
   "description": "Tiling window manager",
   "settings-schema": "org.gnome.shell.extensions.tilingnome",
-  "shell-version": ["3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26"],
+  "shell-version": ["3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26", "3.30"],
   "url": "https://github.com/rliang/gnome-shell-extension-tilingnome",
   "uuid": "tilingnome@rliang.github.com"
 }

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,40 @@
+/*
+ * Excerpted from the Dash-To-Panel extension for Gnome 3
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Credits:
+ * This file is based on code from the Dash to Dock extension by micheleg
+ * and code from the Taskbar extension by Zorin OS
+ * Some code was also adapted from the upstream Gnome Shell source code.
+ */
+
+const Meta = imports.gi.Meta;
+
+// This is wrapper to maintain compatibility with GNOME-Shell 3.30+ as well as
+// previous versions.
+var DisplayWrapper = {
+  getScreen: function() {
+      return global.screen || global.display;
+  },
+
+  getWorkspaceManager: function() {
+      return global.screen || global.workspace_manager;
+  },
+
+  getMonitorManager: function() {
+      return global.screen || Meta.MonitorManager.get();
+  }
+};


### PR DESCRIPTION
Updates extension for Gnome Shell 3.30 while keeping support for earlier versions, using the DisplayWrapper helper from the dash-to-panel extension (https://github.com/home-sweet-gnome/dash-to-panel/blob/5e0f64ed5a8db0cd2808865f1d4cf1f1deee55b7/utils.js#L185)

(For the related issue on the dash-to-panel extension repository, see https://github.com/home-sweet-gnome/dash-to-panel/issues/434)