### PR TITLE
Don't consider minimized windows when tiling

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -69,6 +69,7 @@ function refreshMonitor(mon) {
   const wins = wksp.list_windows()
     .filter(win => win.get_monitor() === mon)
     .filter(win => !win.fullscreen)
+    .filter(win => !win.minimized)
     .filter(tileInfo)
     .sort(tileSort);
   if (wins.length === 1 && settings.get_boolean('maximize-single'))


### PR DESCRIPTION
Minimised windows don't render, so considering them leaves giant gaps in the
layout. This removes them so if a window is the only non-minimised windows, it's
maximised.